### PR TITLE
Fixed module loading in NodeJS.

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,7 +1,7 @@
 var requirejs = require('requirejs');
 
 requirejs.config({
-  baseUrl: '.',
+  baseUrl: __dirname,
   nodeRequire: require
 });
 


### PR DESCRIPTION
Fixed the following error when loading from NodeJS:
Error: Tried loading "src/parser" at ./src/parser.js then tried node's require("src/parser") and it failed with error: Error: Cannot find module 'src/parser'
