### PR TITLE
Switch to UMD wrapper and deprecate requirejs dependency

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,8 +1,0 @@
-var requirejs = require('requirejs');
-
-requirejs.config({
-  baseUrl: __dirname,
-  nodeRequire: require
-});
-
-module.exports = requirejs('./src/parser');

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "css-font-parser",
   "version": "0.2.1",
   "description": "A parser for the CSS font value",
-  "main": "index.js",
+  "main": "lib/parser.js",
   "directories": {
     "test": "test"
   },
@@ -17,9 +17,6 @@
   ],
   "author": "Bram Stein <b.l.stein@gmail.com> (http://www.bramstein.com)",
   "license": "BSD",
-  "dependencies": {
-    "requirejs": "=2.1.8"
-  },
   "devDependencies": {
     "mocha": "=1.12.0",
     "expect.js": "=0.2.0",

--- a/src/parser.js
+++ b/src/parser.js
@@ -1,4 +1,19 @@
-define(function () {
+(function (root, factory) {
+    if (typeof define === 'function' && define.amd) {
+        // AMD. Register as an anonymous module.
+        define([], function () {
+            return (root.returnExportsGlobal = factory());
+        });
+    } else if (typeof module === 'object' && module.exports) {
+        // Node. Does not work with strict CommonJS, but
+        // only CommonJS-like environments that support module.exports,
+        // like Node.
+        module.exports = factory();
+    } else {
+        // Browser globals
+        root.cssFontParser = factory();
+    }
+}(this, function (b) {
   /**
    * @enum {number}
    */
@@ -117,4 +132,4 @@ define(function () {
   }
 
   return parse;
-});
+}));

--- a/test/parser-test.js
+++ b/test/parser-test.js
@@ -1,6 +1,6 @@
 if (typeof require !== 'undefined') {
   expect = require('expect.js');
-  parse = require('../index');
+  parse = require('../src/parser');
 }
 
 describe('CSS Font parser', function () {

--- a/test/tap.html
+++ b/test/tap.html
@@ -8,12 +8,10 @@
     <div id="mocha"></div>
     <script src="../node_modules/mocha/mocha.js"></script>
     <script src="../node_modules/expect.js/expect.js"></script>
-    <script>
-      function define(factory) {
-        window.parse = factory();
-      }
-    </script>
     <script src="../src/parser.js"></script>
+    <script>
+      window.parse = window.cssFontParser;
+    </script>
     <script>mocha.ui('bdd').reporter('tap');</script>
     <script src="./parser-test.js"></script>
     <script>


### PR DESCRIPTION
The use of requirejs was causing errors in the assetgraph test suite. There are global leaks from the use of requirejs in the way it was used. Also, there's no real reason to include requirejs as a dependency at all with the UMD pattern