### PR TITLE
Add support for CSS Fonts Module level 4 features

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+package-lock = false

--- a/src/parser.js
+++ b/src/parser.js
@@ -37,8 +37,8 @@
     var identifiers = str.replace(/^\s+|\s+$/, '').replace(/\s+/g, ' ').split(' ');
 
     for (var i = 0; i < identifiers.length; i += 1) {
-      if (/^(-?\d|--)/.test(identifiers[i]) ||
-           !/^([_a-zA-Z0-9-]|[^\0-\237]|(\\[0-9a-f]{1,6}(\r\n|[ \n\r\t\f])?|\\[^\n\r\f0-9a-f]))+$/.test(identifiers[i])) {
+      if (/^(?:-?\d|--)/.test(identifiers[i]) ||
+           !/^(?:[_a-zA-Z0-9-]|[^\0-\237]|(?:\\[0-9a-f]{1,6}(?:\r\n|[ \n\r\t\f])?|\\[^\n\r\f0-9a-f]))+$/.test(identifiers[i])) {
         return null;
       }
     }
@@ -95,9 +95,9 @@
         }
         state = states.VARIATION;
       } else if (state === states.VARIATION && (c === ' ' || c === '/')) {
-        if (/^((xx|x)-large|(xx|s)-small|small|large|medium)$/.test(buffer) ||
-            /^(larg|small)er$/.test(buffer) ||
-            /^(\+|-)?([0-9]*\.)?[0-9]+(em|ex|ch|rem|vh|vw|vmin|vmax|px|mm|cm|in|pt|pc|%)$/.test(buffer)) {
+        if (/^(?:(?:xx|x)-large|(?:xx|s)-small|small|large|medium)$/.test(buffer) ||
+            /^(?:larg|small)er$/.test(buffer) ||
+            /^(?:\+|-)?(?:[0-9]*\.)?[0-9]+(?:em|ex|ch|rem|vh|vw|vmin|vmax|px|mm|cm|in|pt|pc|%)$/.test(buffer)) {
           state = c === '/' ? states.LINE_HEIGHT : states.BEFORE_FONT_FAMILY;
           result['font-size'] = buffer;
         } else if (/^italic$/.test(buffer)) {
@@ -107,14 +107,14 @@
           state = states.AFTER_OBLIQUE;
         } else if (/^small-caps$/.test(buffer)) {
           result['font-variant'] = buffer;
-        } else if (/^(bold(er)?|lighter|[1-9][0-9]{0,2}|1000)$/.test(buffer)) {
+        } else if (/^(?:bold(?:er)?|lighter|[1-9][0-9]{0,2}|1000)$/.test(buffer)) {
           result['font-weight'] = buffer;
-        } else if (/^((ultra|extra|semi)-)?(condensed|expanded)$/.test(buffer)) {
+        } else if (/^(?:(?:ultra|extra|semi)-)?(?:condensed|expanded)$/.test(buffer)) {
           result['font-stretch'] = buffer;
         }
         buffer = '';
       } else if (state === states.LINE_HEIGHT && c === ' ') {
-        if (/^(\+|-)?([0-9]*\.)?[0-9]+(em|ex|ch|rem|vh|vw|vmin|vmax|px|mm|cm|in|pt|pc|%)?$/.test(buffer)) {
+        if (/^(?:\+|-)?([0-9]*\.)?[0-9]+(?:em|ex|ch|rem|vh|vw|vmin|vmax|px|mm|cm|in|pt|pc|%)?$/.test(buffer)) {
           result['line-height'] = buffer;
         }
         state = states.BEFORE_FONT_FAMILY;

--- a/src/parser.js
+++ b/src/parser.js
@@ -107,8 +107,13 @@
           state = states.AFTER_OBLIQUE;
         } else if (/^small-caps$/.test(buffer)) {
           result['font-variant'] = buffer;
-        } else if (/^(?:bold(?:er)?|lighter|[1-9][0-9]{0,2}(?:\.[0-9]+)?|1000(?:\.0+)?)$/.test(buffer)) {
+        } else if (/^(?:bold(?:er)?|lighter)$/.test(buffer)) {
           result['font-weight'] = buffer;
+        } else if (/^[+-]?(?:[0-9]*\.)?[0-9]+(?:e[+-]?(?:0|[1-9][0-9]*))?$/.test(buffer)) {
+          var num = parseFloat(buffer);
+          if (num >= 1 && num <= 1000) {
+            result['font-weight'] = buffer;
+          }
         } else if (/^(?:(?:ultra|extra|semi)-)?(?:condensed|expanded)$/.test(buffer)) {
           result['font-stretch'] = buffer;
         }

--- a/src/parser.js
+++ b/src/parser.js
@@ -93,7 +93,7 @@
           result['font-style'] = buffer;
         } else if (/^small-caps$/.test(buffer)) {
           result['font-variant'] = buffer;
-        } else if (/^(bold(er)?|lighter|[1-9]00)$/.test(buffer)) {
+        } else if (/^(bold(er)?|lighter|[1-9][0-9]{0,2}|1000)$/.test(buffer)) {
           result['font-weight'] = buffer;
         } else if (/^((ultra|extra|semi)-)?(condensed|expanded)$/.test(buffer)) {
           result['font-stretch'] = buffer;

--- a/src/parser.js
+++ b/src/parser.js
@@ -107,7 +107,7 @@
           state = states.AFTER_OBLIQUE;
         } else if (/^small-caps$/.test(buffer)) {
           result['font-variant'] = buffer;
-        } else if (/^(?:bold(?:er)?|lighter|[1-9][0-9]{0,2}|1000)$/.test(buffer)) {
+        } else if (/^(?:bold(?:er)?|lighter|[1-9][0-9]{0,2}(?:\.[0-9]+)?|1000(?:\.0+)?)$/.test(buffer)) {
           result['font-weight'] = buffer;
         } else if (/^(?:(?:ultra|extra|semi)-)?(?:condensed|expanded)$/.test(buffer)) {
           result['font-stretch'] = buffer;

--- a/test/parser-test.js
+++ b/test/parser-test.js
@@ -142,9 +142,17 @@ describe('CSS Font parser', function () {
     expect(parse('bolder 12px serif')).to.eql({ 'font-size': '12px', 'font-weight': 'bolder', 'font-family': ['serif'] });
     expect(parse('lighter 12px serif')).to.eql({ 'font-size': '12px', 'font-weight': 'lighter', 'font-family': ['serif'] });
 
-    for (var i = 1; i < 10; i += 1) {
+    for (var i = 1; i <= 10; i += 1) {
       expect(parse(i * 100 + ' 12px serif')).to.eql({ 'font-size': '12px', 'font-weight': i * 100, 'font-family': ['serif'] });
     }
+
+    expect(parse('1 12px serif')).to.eql({ 'font-size': '12px', 'font-weight': '1', 'font-family': ['serif'] });
+    expect(parse('723 12px serif')).to.eql({ 'font-size': '12px', 'font-weight': '723', 'font-family': ['serif'] });
+    expect(parse('1000 12px serif')).to.eql({ 'font-size': '12px', 'font-weight': '1000', 'font-family': ['serif'] });
+
+    expect(parse('0 12px serif')).to.eql({ 'font-size': '12px', 'font-family': ['serif'] });
+    expect(parse('1001 12px serif')).to.eql({ 'font-size': '12px', 'font-family': ['serif'] });
+    expect(parse('100.0 12px serif')).to.eql({ 'font-size': '12px', 'font-family': ['serif'] });
   });
 
   it('correctly parses font-stretch', function () {

--- a/test/parser-test.js
+++ b/test/parser-test.js
@@ -153,12 +153,19 @@ describe('CSS Font parser', function () {
     expect(parse('723 12px serif')).to.eql({ 'font-size': '12px', 'font-weight': '723', 'font-family': ['serif'] });
     expect(parse('1000 12px serif')).to.eql({ 'font-size': '12px', 'font-weight': '1000', 'font-family': ['serif'] });
     expect(parse('1000.00 12px serif')).to.eql({ 'font-size': '12px', 'font-weight': '1000.00', 'font-family': ['serif'] });
+    expect(parse('1e3 12px serif')).to.eql({ 'font-size': '12px', 'font-weight': '1e3', 'font-family': ['serif'] });
+    expect(parse('1e+1 12px serif')).to.eql({ 'font-size': '12px', 'font-weight': '1e+1', 'font-family': ['serif'] });
+    expect(parse('200e-2 12px serif')).to.eql({ 'font-size': '12px', 'font-weight': '200e-2', 'font-family': ['serif'] });
     expect(parse('123.456 12px serif')).to.eql({ 'font-size': '12px', 'font-weight': '123.456', 'font-family': ['serif'] });
+    expect(parse('+123 12px serif')).to.eql({ 'font-size': '12px', 'font-weight': '+123', 'font-family': ['serif'] });
 
     expect(parse('0 12px serif')).to.eql({ 'font-size': '12px', 'font-family': ['serif'] });
+    expect(parse('-1 12px serif')).to.eql({ 'font-size': '12px', 'font-family': ['serif'] });
     expect(parse('1000. 12px serif')).to.eql({ 'font-size': '12px', 'font-family': ['serif'] });
     expect(parse('1000.1 12px serif')).to.eql({ 'font-size': '12px', 'font-family': ['serif'] });
     expect(parse('1001 12px serif')).to.eql({ 'font-size': '12px', 'font-family': ['serif'] });
+    expect(parse('1.1e3 12px serif')).to.eql({ 'font-size': '12px', 'font-family': ['serif'] });
+    expect(parse('1e-2 12px serif')).to.eql({ 'font-size': '12px', 'font-family': ['serif'] });
   });
 
   it('correctly parses font-stretch', function () {

--- a/test/parser-test.js
+++ b/test/parser-test.js
@@ -131,6 +131,9 @@ describe('CSS Font parser', function () {
   it('correctly parses font-style', function () {
     expect(parse('italic 12px serif')).to.eql({ 'font-size': '12px', 'font-style': 'italic', 'font-family': ['serif'] });
     expect(parse('oblique 12px serif')).to.eql({ 'font-size': '12px', 'font-style': 'oblique', 'font-family': ['serif'] });
+    expect(parse('oblique 20deg 12px serif')).to.eql({ 'font-size': '12px', 'font-style': 'oblique 20deg', 'font-family': ['serif'] });
+    expect(parse('oblique 0.02turn 12px serif')).to.eql({ 'font-size': '12px', 'font-style': 'oblique 0.02turn', 'font-family': ['serif'] });
+    expect(parse('oblique .04rad 12px serif')).to.eql({ 'font-size': '12px', 'font-style': 'oblique .04rad', 'font-family': ['serif'] });
   });
 
   it('correctly parses font-variant', function () {

--- a/test/parser-test.js
+++ b/test/parser-test.js
@@ -152,10 +152,13 @@ describe('CSS Font parser', function () {
     expect(parse('1 12px serif')).to.eql({ 'font-size': '12px', 'font-weight': '1', 'font-family': ['serif'] });
     expect(parse('723 12px serif')).to.eql({ 'font-size': '12px', 'font-weight': '723', 'font-family': ['serif'] });
     expect(parse('1000 12px serif')).to.eql({ 'font-size': '12px', 'font-weight': '1000', 'font-family': ['serif'] });
+    expect(parse('1000.00 12px serif')).to.eql({ 'font-size': '12px', 'font-weight': '1000.00', 'font-family': ['serif'] });
+    expect(parse('123.456 12px serif')).to.eql({ 'font-size': '12px', 'font-weight': '123.456', 'font-family': ['serif'] });
 
     expect(parse('0 12px serif')).to.eql({ 'font-size': '12px', 'font-family': ['serif'] });
+    expect(parse('1000. 12px serif')).to.eql({ 'font-size': '12px', 'font-family': ['serif'] });
+    expect(parse('1000.1 12px serif')).to.eql({ 'font-size': '12px', 'font-family': ['serif'] });
     expect(parse('1001 12px serif')).to.eql({ 'font-size': '12px', 'font-family': ['serif'] });
-    expect(parse('100.0 12px serif')).to.eql({ 'font-size': '12px', 'font-family': ['serif'] });
   });
 
   it('correctly parses font-stretch', function () {


### PR DESCRIPTION
* Support font weights between 1 and 1000 inclusive.
* Support `oblique` followed by an angle: https://www.w3.org/TR/css-fonts-4/#valdef-font-style-oblique-angle