### PR TITLE
Add font-weight normal keyword

### DIFF
--- a/src/parser.js
+++ b/src/parser.js
@@ -107,7 +107,7 @@
           state = states.AFTER_OBLIQUE;
         } else if (/^small-caps$/.test(buffer)) {
           result['font-variant'] = buffer;
-        } else if (/^(?:bold(?:er)?|lighter)$/.test(buffer)) {
+        } else if (/^(?:bold(?:er)?|lighter|normal)$/.test(buffer)) {
           result['font-weight'] = buffer;
         } else if (/^[+-]?(?:[0-9]*\.)?[0-9]+(?:e[+-]?(?:0|[1-9][0-9]*))?$/.test(buffer)) {
           var num = parseFloat(buffer);

--- a/test/parser-test.js
+++ b/test/parser-test.js
@@ -144,6 +144,7 @@ describe('CSS Font parser', function () {
     expect(parse('bold 12px serif')).to.eql({ 'font-size': '12px', 'font-weight': 'bold', 'font-family': ['serif'] });
     expect(parse('bolder 12px serif')).to.eql({ 'font-size': '12px', 'font-weight': 'bolder', 'font-family': ['serif'] });
     expect(parse('lighter 12px serif')).to.eql({ 'font-size': '12px', 'font-weight': 'lighter', 'font-family': ['serif'] });
+    expect(parse('normal 12px serif')).to.eql({ 'font-size': '12px', 'font-weight': 'normal', 'font-family': ['serif'] });
 
     for (var i = 1; i <= 10; i += 1) {
       expect(parse(i * 100 + ' 12px serif')).to.eql({ 'font-size': '12px', 'font-weight': i * 100, 'font-family': ['serif'] });


### PR DESCRIPTION
Added `normal` as valid font-weight value, https://developer.mozilla.org/en-US/docs/Web/CSS/font-weight.