### PR TITLE
chore: use valid spdx identifier for license

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "parser"
   ],
   "author": "Bram Stein <b.l.stein@gmail.com> (http://www.bramstein.com)",
-  "license": "BSD",
+  "license": "BSD-3-Clause",
   "devDependencies": {
     "eslint": "^8.20.0",
     "eslint-config-prettier": "^8.5.0",


### PR DESCRIPTION
This uses a valid [spdx identifier](https://spdx.org/licenses/) for the license of this repository, which is "BSD-3-Clause" according to the README.

It would be great, if you could publish a new version containing this change :rocket: 